### PR TITLE
Add github actions CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    push:
+      branches:
+        - master
+
+jobs:
+  build_and_test:
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo clippy
+      - run: cargo build
+      - run: cargo test


### PR DESCRIPTION
This basically runs `cargo build` and `cargo test` on current stable
toolchain, for pull requests and after push to master (i.e. PR merged).